### PR TITLE
Added abs. ticks and direction (xESC2040 FW 0.10 support)

### DIFF
--- a/xesc_2040_driver/include/xesc_2040_driver/xesc_2040_datatypes.h
+++ b/xesc_2040_driver/include/xesc_2040_driver/xesc_2040_datatypes.h
@@ -22,12 +22,14 @@ struct Xesc2040StatusPacket {
     uint32_t seq;
     uint8_t fw_version_major;
     uint8_t fw_version_minor;
-    double voltage_input;        // input voltage (volt)
-    double temperature_pcb;      // temperature of printed circuit board (degrees Celsius)
-    double temperature_motor;      // temperature of printed circuit board (degrees Celsius)
-    double current_input;        // input current (ampere)
-    double duty_cycle;           // duty cycle (0 to 1)
+    double voltage_input;       // input voltage (volt)
+    double temperature_pcb;     // temperature of printed circuit board (degrees Celsius)
+    double temperature_motor;   // temperature of printed circuit board (degrees Celsius)
+    double current_input;       // input current (ampere)
+    double duty_cycle;          // duty cycle (0 to 1)
     uint32_t tacho;
+    uint32_t tacho_absolute;    // wheel ticks absolute
+    bool direction;             // direction CW/CCW
     int32_t fault_code;
     uint16_t crc;
 } __attribute__((packed));

--- a/xesc_2040_driver/include/xesc_2040_driver/xesc_2040_interface.h
+++ b/xesc_2040_driver/include/xesc_2040_driver/xesc_2040_interface.h
@@ -33,12 +33,14 @@ namespace xesc_2040_driver {
         uint8_t fw_version_major;
         uint8_t fw_version_minor;
         XESC2040_CONNECTION_STATE connection_state;
-        double voltage_input;        // input voltage (volt)
-        double temperature_pcb;      // temperature of printed circuit board (degrees Celsius)
-        double temperature_motor;      // temperature of printed circuit board (degrees Celsius)
-        double current_input;        // input current (ampere)
-        double duty_cycle;           // duty cycle (0 to 1)
+        double voltage_input;       // input voltage (volt)
+        double temperature_pcb;     // temperature of printed circuit board (degrees Celsius)
+        double temperature_motor;   // temperature of printed circuit board (degrees Celsius)
+        double current_input;       // input current (ampere)
+        double duty_cycle;          // duty cycle (0 to 1)
         uint32_t tacho;
+        uint32_t tacho_absolute;    // wheel ticks absolute
+        bool direction;             // direction CW/CCW
         int32_t fault_code;
     };
 

--- a/xesc_2040_driver/src/xesc_2040_driver.cpp
+++ b/xesc_2040_driver/src/xesc_2040_driver.cpp
@@ -91,6 +91,8 @@ void xesc_2040_driver::Xesc2040Driver::getStatus(xesc_msgs::XescStateStamped &st
     state_msg.state.current_input = status.current_input;
     state_msg.state.duty_cycle = status.duty_cycle;
     state_msg.state.tacho = status.tacho;
+    state_msg.state.tacho_absolute = status.tacho_absolute;
+    state_msg.state.direction = status.direction;
     state_msg.state.fault_code = status.fault_code;
 }
 
@@ -109,6 +111,8 @@ void xesc_2040_driver::Xesc2040Driver::getStatusBlocking(xesc_msgs::XescStateSta
     state_msg.state.current_input = status.current_input;
     state_msg.state.duty_cycle = status.duty_cycle;
     state_msg.state.tacho = status.tacho;
+    state_msg.state.tacho_absolute = status.tacho_absolute;
+    state_msg.state.direction = status.direction;
     state_msg.state.fault_code = status.fault_code;
 }
 

--- a/xesc_2040_driver/src/xesc_2040_interface.cpp
+++ b/xesc_2040_driver/src/xesc_2040_interface.cpp
@@ -145,6 +145,8 @@ namespace xesc_2040_driver {
             status_.current_input = packet->current_input;
             status_.duty_cycle = packet->duty_cycle;
             status_.tacho = packet->tacho;
+            status_.tacho_absolute = packet->tacho_absolute;
+            status_.direction = packet->direction;
             status_.fault_code = packet->fault_code;
 
             // If unconfigured, send settings


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
xESC2040 FW 0.10 support

## Details
Required for absolute wheel tick and direction support

## Impacts
Requires pull request https://github.com/ClemensElflein/xESC2040/pull/9
